### PR TITLE
Feat/update graphing docs

### DIFF
--- a/.changeset/chatty-baboons-study.md
+++ b/.changeset/chatty-baboons-study.md
@@ -1,0 +1,5 @@
+---
+'nestjs-spelunker': patch
+---
+
+Removes cyclic dependencies caveat in README Graph Mode

--- a/README.md
+++ b/README.md
@@ -123,8 +123,6 @@ graph LR
 
 The edges can certainly be transformed into formats more suitable for other visualization tools. And the graph can be traversed with other strategies.
 
-NOTE: Circular dependencies are currently, naively dealt with by arbitrarily ending recursion at a depth of 20.
-
 ## Debug Mode
 
 Every now again again you may find yourself running into problems where Nest can't resolve a provider's dependencies. The `SpelunkerModule` has a `debug` method that's meant to help out with this kind of situation.

--- a/test/large-app/app.e2e-spec.ts
+++ b/test/large-app/app.e2e-spec.ts
@@ -53,13 +53,16 @@ SpelunkerSuite('Should allow the SpelunkerModule to graph', ({ app }) => {
   );
 });
 
-SpelunkerSuite('Should handle a module circular dependency', ({ app }) => {
-  const tree = SpelunkerModule.explore(app);
-  tree.at(-1)?.imports.push('AppModule');
-  const root = SpelunkerModule.graph(tree);
-  const edges = SpelunkerModule.findGraphEdges(root);
-  equal(
-    edges.map((e) => `${e.from.module.name}-->${e.to.module.name}`),
-    cyclicGraphEdgesOutput,
-  );
-});
+SpelunkerSuite(
+  'Should handle a module circular dependency when finding graph edges',
+  ({ app }) => {
+    const tree = SpelunkerModule.explore(app);
+    tree.slice(-1)[0].imports.push('AppModule');
+    const root = SpelunkerModule.graph(tree);
+    const edges = SpelunkerModule.findGraphEdges(root);
+    equal(
+      edges.map((e) => `${e.from.module.name}-->${e.to.module.name}`),
+      cyclicGraphEdgesOutput,
+    );
+  },
+);


### PR DESCRIPTION
Oops, neglected to remove the cycl dep caveat from the README. Do you want me to change the Array.at use in the e2e? Its already standard ts/js syntax, but I can see you'd want assurance that the tests run in older nodejs versions.