### PR TITLE
fix: false-positive for providers with falsy values

### DIFF
--- a/.changeset/silent-dogs-decide.md
+++ b/.changeset/silent-dogs-decide.md
@@ -1,0 +1,5 @@
+---
+'nestjs-spelunker': patch
+---
+
+Allow value and factory providers to have falsy values instead of treating them as a class providers

--- a/src/debug.module.ts
+++ b/src/debug.module.ts
@@ -14,12 +14,15 @@ import {
 } from './spelunker.interface';
 import { UndefinedClassObject } from './spelunker.messages';
 
-function isObject(val: any): val is object {
+function isObject(val: any): val is Record<any, any> {
   const isNil = val == null;
   return !isNil && typeof val === 'object';
 }
 
-function hasProp(val: any, property: string): boolean {
+function hasProp<T extends string = string>(
+  val: any,
+  property: T,
+): val is Record<T, any> {
   return isObject(val) && Object.prototype.hasOwnProperty.call(val, property);
 }
 

--- a/src/debug.module.ts
+++ b/src/debug.module.ts
@@ -14,6 +14,15 @@ import {
 } from './spelunker.interface';
 import { UndefinedClassObject } from './spelunker.messages';
 
+function isObject(val: any): val is object {
+  const isNil = val == null;
+  return !isNil && typeof val === 'object';
+}
+
+function hasProp(val: any, property: string): boolean {
+  return isObject(val) && Object.prototype.hasOwnProperty.call(property);
+}
+
 export class DebugModule {
   private static seenModules: Type<any>[] = [];
   static async debug(
@@ -243,10 +252,10 @@ export class DebugModule {
           dependencies: [],
           type: 'class',
         };
-        if (provider.useValue) {
+        if (hasProp(provider, 'useValue')) {
           newProvider.type = 'value';
           dependencies = () => [];
-        } else if (provider.useFactory) {
+        } else if (hasProp(provider, 'useFactory')) {
           newProvider.type = 'factory';
           dependencies = () =>
             (provider.inject ?? []).map(this.getProviderName);

--- a/src/debug.module.ts
+++ b/src/debug.module.ts
@@ -20,7 +20,7 @@ function isObject(val: any): val is object {
 }
 
 function hasProp(val: any, property: string): boolean {
-  return isObject(val) && Object.prototype.hasOwnProperty.call(property);
+  return isObject(val) && Object.prototype.hasOwnProperty.call(val, property);
 }
 
 export class DebugModule {
@@ -259,10 +259,14 @@ export class DebugModule {
           newProvider.type = 'factory';
           dependencies = () =>
             (provider.inject ?? []).map(this.getProviderName);
-        } else {
+        } else if (hasProp(provider, 'useClass')) {
           newProvider.type = 'class';
-          dependencies = () =>
-            this.getDependencies(provider.useClass ?? provider.useExisting);
+          dependencies = () => this.getDependencies(provider.useClass);
+        } else if (hasProp(provider, 'useExisting')) {
+          newProvider.type = 'class';
+          dependencies = () => this.getDependencies(provider.useExisting);
+        } else {
+          throw new Error('Unknown provider type');
         }
         newProvider.dependencies = dependencies();
         debuggedProviders.push(newProvider);


### PR DESCRIPTION
I just found a edge-case while trying this tool with `create-nestjs-middleware-module` package which has a provider that could be `null` but is not optional:

https://github.com/iamolegga/create-nestjs-middleware-module/blob/85e89cc93b6b1f7707a4fa37c8f85d2b7be40cc6/src/index.ts#L98-L101
